### PR TITLE
Moving collector's common from ingress-api-client-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rake"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
+gem "topological_inventory-providers-common",   :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 
 group :test, :development do
   gem "rspec"

--- a/lib/topological_inventory/azure/collector.rb
+++ b/lib/topological_inventory/azure/collector.rb
@@ -1,14 +1,13 @@
 require "concurrent"
-require "topological_inventory-ingress_api-client/collector"
+require "topological_inventory/providers/common/collector"
 require "topological_inventory/azure/connection"
 require "topological_inventory/azure/parser"
 require "topological_inventory/azure/iterator"
 require "topological_inventory/azure/logging"
-require "topological_inventory-ingress_api-client"
 
 module TopologicalInventory
   module Azure
-    class Collector < ::TopologicalInventoryIngressApiClient::Collector
+    class Collector < ::TopologicalInventory::Providers::Common::Collector
       include Logging
 
       require "topological_inventory/azure/collector/compute"

--- a/lib/topological_inventory/azure/collectors_pool.rb
+++ b/lib/topological_inventory/azure/collectors_pool.rb
@@ -1,9 +1,9 @@
-require "topological_inventory-ingress_api-client/collectors_pool"
+require "topological_inventory/providers/common/collectors_pool"
 require "topological_inventory/azure/collector"
 require "topological_inventory/azure/logging"
 
 module TopologicalInventory::Azure
-  class CollectorsPool < TopologicalInventoryIngressApiClient::CollectorsPool
+  class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
     def initialize(config_name, metrics, poll_time: 5)

--- a/lib/topological_inventory/azure/parser.rb
+++ b/lib/topological_inventory/azure/parser.rb
@@ -1,19 +1,17 @@
-require "active_support/inflector"
-require "topological_inventory/azure/parser/flavor"
-require "topological_inventory/azure/parser/floating_ip"
-require "topological_inventory/azure/parser/network"
-require "topological_inventory/azure/parser/network_adapter"
-require "topological_inventory/azure/parser/security_group"
-require "topological_inventory/azure/parser/source_region"
-require "topological_inventory/azure/parser/vm"
-require "topological_inventory/azure/parser/volume"
-require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/collector.rb"
-require "topological_inventory-ingress_api-client/collector/inventory_collection_storage.rb"
+require "topological_inventory/providers/common/collector/parser"
 
 module TopologicalInventory
   module Azure
-    class Parser
+    class Parser < TopologicalInventory::Providers::Common::Collector::Parser
+      require "topological_inventory/azure/parser/flavor"
+      require "topological_inventory/azure/parser/floating_ip"
+      require "topological_inventory/azure/parser/network"
+      require "topological_inventory/azure/parser/network_adapter"
+      require "topological_inventory/azure/parser/security_group"
+      require "topological_inventory/azure/parser/source_region"
+      require "topological_inventory/azure/parser/vm"
+      require "topological_inventory/azure/parser/volume"
+
       include Parser::Flavor
       include Parser::FloatingIp
       include Parser::Network
@@ -23,12 +21,11 @@ module TopologicalInventory
       include Parser::Vm
       include Parser::Volume
 
-      attr_accessor :connection, :collections, :resource_timestamp
+      attr_accessor :connection
 
       def initialize(connection = nil)
+        super()
         self.connection         = connection
-        self.resource_timestamp = Time.now.utc
-        self.collections = TopologicalInventoryIngressApiClient::Collector::InventoryCollectionStorage.new
       end
 
       private
@@ -36,14 +33,6 @@ module TopologicalInventory
       def archive_entity(inventory_object, entity)
         source_deleted_at                  = entity.metadata&.deletionTimestamp || Time.now.utc
         inventory_object.source_deleted_at = source_deleted_at
-      end
-
-      def lazy_find(collection, reference, ref: :manager_ref)
-        TopologicalInventoryIngressApiClient::InventoryObjectLazy.new(
-          :inventory_collection_name => collection,
-          :reference                 => reference,
-          :ref                       => ref
-        )
       end
     end
   end


### PR DESCRIPTION
to providers-common gem, because ingress-api-client is built from generator

---

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-providers-common/pull/1

- [x]  **Note**: Based on https://github.com/ManageIQ/topological_inventory-azure/pull/1, needs rebase