### PR TITLE
Fix the collector spec now that we strip null refs

### DIFF
--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe TopologicalInventory::Azure::Collector do
            :name          => "Instance Name 1",
            :power_state   => "powering_down",
            :source_ref    => "instanceid1",
-           :source_region =>
-                             {:inventory_collection_name => :source_regions,
-                              :reference                 => {:source_ref => nil},
-                              :ref                       => :manager_ref},
            :subscription  =>
                              {:inventory_collection_name => :subscriptions,
                               :reference                 => {:source_ref => "subscription1"},


### PR DESCRIPTION
After https://github.com/ManageIQ/topological_inventory-providers-common/pull/4 we need to update the collector spec to not look for nil references

Fixes https://travis-ci.com/ManageIQ/topological_inventory-azure/jobs/248332352#L329-L346