### PR TITLE
SecurityGroup's network parser fix

### DIFF
--- a/lib/topological_inventory/azure/parser/security_group.rb
+++ b/lib/topological_inventory/azure/parser/security_group.rb
@@ -15,8 +15,7 @@ module TopologicalInventory::Azure
           :subscription        => lazy_find(:subscriptions, :source_ref => scope[:subscription_id]),
           :source_region       => lazy_find(:source_regions, :source_ref => sg.location),
           :orchestration_stack => nil,
-          # TODO: Probably err in  openapi.json, should be :network => nil
-          :network_id          => nil
+          :network             => nil
         )
 
         parse_security_group_tags(sg.id, sg.tags)

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe TopologicalInventory::Azure::Collector do
           {:description         => nil,
            :extra               => {:provisioning_state => "Succeeded"},
            :name                => "security_group_name_1",
-           :network_id          => nil, # TODO: should be :network
+           :network             => nil,
            :orchestration_stack => nil,
            :source_ref          => "security_group_id_1",
            :source_region       =>


### PR DESCRIPTION
Restored SecurityGroup -> Network collecting

---

* [ ] **depends on** https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/62