### PR TITLE
Standalone mode switch for multisource ThreadPool

### DIFF
--- a/lib/topological_inventory/azure/collector.rb
+++ b/lib/topological_inventory/azure/collector.rb
@@ -16,10 +16,12 @@ module TopologicalInventory
       include Azure::Collector::Compute
       include Azure::Collector::Network
 
-      def initialize(source, client_id, client_secret, tenant_id, metrics, default_limit: 1_000, poll_time: 5)
+      def initialize(source, client_id, client_secret, tenant_id, metrics,
+                     default_limit: 1_000, poll_time: 30, standalone_mode: true)
         super(source,
-              :default_limit => default_limit,
-              :poll_time     => poll_time)
+              :default_limit   => default_limit,
+              :poll_time       => poll_time,
+              :standalone_mode => standalone_mode)
 
         self.client_id     = client_id
         self.client_secret = client_secret
@@ -37,7 +39,7 @@ module TopologicalInventory
             logger.error(e)
             metrics.record_error
           ensure
-            sleep(30)
+            standalone_mode ? sleep(poll_time) : stop
           end
         end
       end

--- a/lib/topological_inventory/azure/collectors_pool.rb
+++ b/lib/topological_inventory/azure/collectors_pool.rb
@@ -6,7 +6,7 @@ module TopologicalInventory::Azure
   class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
-    def initialize(config_name, metrics, poll_time: 5)
+    def initialize(config_name, metrics)
       super
     end
 
@@ -29,7 +29,7 @@ module TopologicalInventory::Azure
     end
 
     def new_collector(source, secret)
-      TopologicalInventory::Azure::Collector.new(source.source, secret['username'], secret['password'], secret['tenant_id'], metrics)
+      TopologicalInventory::Azure::Collector.new(source.source, secret['username'], secret['password'], secret['tenant_id'], metrics, :standalone_mode => false)
     end
   end
 end


### PR DESCRIPTION
MultiSource mode will schedule running of collectors. It means in this mode collecting isn't run i the loop.

---

-  **depends on [mutual]** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11