### PR TITLE
The auth.extra attribute is a hash not an object

### DIFF
--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -54,7 +54,7 @@ module TopologicalInventory
           TopologicalInventory::Azure::Connection.all_subscriptions(
             :client_id => auth.username,
             :client_secret => auth.password,
-            :tenant_id     => auth.extra&.azure&.tenant_id
+            :tenant_id     => auth.extra&.dig("azure", "tenant_id")
           )
 
           STATUS_AVAILABLE


### PR DESCRIPTION
Don't call .azure.tenant_id on a hash

`{"@timestamp":"2020-02-11T12:40:03.371214 ","hostname":"topological-inventory-azure-operations-5-s8vcf","pid":1,"tid":"41c5f8","level":"err","message":"Failed to connect to Source id:34642 - undefined method 'azure' for {\"azure\"=>{\"tenant_id\"=>\"2e64678d-2fa8-40ed-8922-c9b8e2c3f100\"}}:Hash"}`