### PR TITLE
Merge pull request #17 from agrare/fix_undefined_method_auth_extra_hash

### DIFF
--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -54,7 +54,7 @@ module TopologicalInventory
           TopologicalInventory::Azure::Connection.all_subscriptions(
             :client_id => auth.username,
             :client_secret => auth.password,
-            :tenant_id     => auth.extra&.azure&.tenant_id
+            :tenant_id     => auth.extra&.dig("azure", "tenant_id")
           )
 
           STATUS_AVAILABLE


### PR DESCRIPTION
Pull #17 back to stable to fix "the auth.extra attribute is a hash not an object"