### PR TITLE
Add additional logging for availability checks

### DIFF
--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -33,6 +33,7 @@ module TopologicalInventory
           rescue SourcesApiClient::ApiError => e
             logger.error("Failed to update Source id:#{source_id} - #{e.message}")
           end
+          logger.info("Source#availability_check completed: Source #{source_id} is #{source.availability_status}")
         end
 
         private


### PR DESCRIPTION
We now log when an availability check begins and also log the
status after the source is updated.

https://projects.engineering.redhat.com/browse/TPINVTRY-839