### PR TITLE
Adding source_updated_at info to be collected from volumes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 1.0"
-gem "topological_inventory-ingress_api-client", "~> 1.0.1"
+gem "topological_inventory-ingress_api-client", "~> 1.0.2"
 gem "topological_inventory-providers-common", "~> 1.0.2"
 
 group :test, :development do

--- a/lib/topological_inventory/azure/parser/volume.rb
+++ b/lib/topological_inventory/azure/parser/volume.rb
@@ -35,8 +35,7 @@ module TopologicalInventory::Azure
           :name              => data[:blob].name || uri,
           :state             => nil, # TODO: options here are .lease_status and .lease_state
           :source_created_at => nil,
-          # TODO(mslemr) migration to db first
-          #:source_updated_at => data[:blob].properties[:last_modified],
+          :source_updated_at => data[:blob].properties[:last_modified],
           :size              => data[:blob].properties[:content_length],
           :source_region     => lazy_find(:source_regions, :source_ref => data[:storage_account].location),
           :subscription      => lazy_find(:subscriptions, :source_ref => scope[:subscription_id])

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe TopologicalInventory::Azure::Collector do
           {:name              => "my_blob",
            :size              => 32212254720,
            :source_created_at => nil,
+           :source_updated_at => "2012-12-12 20:20",
            :state             => nil,
            :source_ref        => "https://my.blob.azure.com/unmanaged_storage_container/my_blob",
            :source_region     =>


### PR DESCRIPTION
Adding source_updated_at info to be collected from volumes.

related PRs: 
 * [x] **depends on** https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/66
 * [x] **depends on** https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/67
 * https://github.com/RedHatInsights/topological_inventory-core/pull/200
 * https://github.com/RedHatInsights/topological_inventory-ingress_api/pull/91
 * https://github.com/RedHatInsights/topological_inventory-api-client-ruby/pull/33
 * https://github.com/RedHatInsights/topological_inventory-persister/pull/61

based on https://projects.engineering.redhat.com/browse/TPINVTRY-789