### PR TITLE
Add rubocop channel to codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,4 +27,5 @@ checks:
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-69
     config: ".rubocop_cc.yml"


### PR DESCRIPTION
Lock rubocop to version 0.69

Should fix CodeClimate maintainability checking.