### PR TITLE
Availability check based on providers-common gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
-gem "sources-api-client", "~> 1.0"
+gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 1.0.2"
+gem "topological_inventory-providers-common", "~> 1.0.5"
 
 group :test, :development do
   gem "rspec"

--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -1,83 +1,30 @@
-require "sources-api-client"
-require "active_support/core_ext/numeric/time"
+require "topological_inventory/azure/logging"
+require "topological_inventory/providers/common/operations/source"
 require "topological_inventory/azure/connection"
-require "topological_inventory/azure/operations/core/authentication_retriever"
 
 module TopologicalInventory
   module Azure
     module Operations
-      class Source
+      class Source < TopologicalInventory::Providers::Common::Operations::Source
         include Logging
-        STATUS_AVAILABLE, STATUS_UNAVAILABLE = %w[available unavailable].freeze
-
-        attr_accessor :params, :context, :source_id
-
-        def initialize(params = {}, request_context = nil)
-          @params  = params
-          @context = request_context
-          @source_id = nil
-        end
-
-        def availability_check
-          source_id = params["source_id"]
-          unless source_id
-            logger.error("Missing source_id for the availability_check request")
-            return
-          end
-
-          source = SourcesApiClient::Source.new
-          source.availability_status = connection_check(source_id)
-
-          begin
-            api_client.update_source(source_id, source)
-          rescue SourcesApiClient::ApiError => e
-            logger.error("Failed to update Source id:#{source_id} - #{e.message}")
-          end
-          logger.info("Source#availability_check completed: Source #{source_id} is #{source.availability_status}")
-        end
 
         private
 
         def connection_check(source_id)
-          endpoints = api_client.list_source_endpoints(source_id)&.data || []
-          endpoint = endpoints.find(&:default)
-          return STATUS_UNAVAILABLE unless endpoint
-
-          endpoint_authentications = api_client.list_endpoint_authentications(endpoint.id.to_s).data || []
-          return STATUS_UNAVAILABLE if endpoint_authentications.empty?
-
-          auth_id = endpoint_authentications.detect { |a| a.authtype == "tenant_id_client_id_client_secret" }&.id
-          return if auth_id.nil?
-
-          auth = Core::AuthenticationRetriever.new(auth_id, identity).process
-          return STATUS_UNAVAILABLE unless auth
-
           TopologicalInventory::Azure::Connection.all_subscriptions(
-            :client_id => auth.username,
-            :client_secret => auth.password,
-            :tenant_id     => auth.extra&.dig("azure", "tenant_id")
+            :client_id     => authentication.username,
+            :client_secret => authentication.password,
+            :tenant_id     => authentication.extra&.dig("azure", "tenant_id")
           )
 
-          STATUS_AVAILABLE
+          [STATUS_AVAILABLE, nil]
         rescue => e
-          logger.error("Failed to connect to Source id:#{source_id} - #{e.message}")
-          STATUS_UNAVAILABLE
+          logger.availability_check("Failed to connect to Source id:#{source_id} - #{e.message}", :error)
+          [STATUS_UNAVAILABLE, e.message]
         end
 
-        def identity
-          @identity ||= { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => params["external_tenant"], "user" => { "is_org_admin" => true }}}.to_json) }
-        end
-
-        def api_client
-          @api_client ||= begin
-            api_client = SourcesApiClient::ApiClient.new
-            api_client.default_headers.merge!(identity)
-            SourcesApiClient::DefaultApi.new(api_client)
-          end
-        end
-
-        def region
-          "us-east-1"
+        def authentication
+          @authentication ||= api_client.fetch_authentication(source_id, endpoint, 'tenant_id_client_id_client_secret')
         end
       end
     end

--- a/spec/application_metrics_spec.rb
+++ b/spec/application_metrics_spec.rb
@@ -4,7 +4,13 @@ require "net/http"
 
 RSpec.describe TopologicalInventory::Azure::Collector::ApplicationMetrics do
   subject! { described_class.new(9394) }
-  after    { subject.stop_server }
+  around do |spec|
+    WebMock.disable!
+    spec.run
+    WebMock.enable!
+  end
+
+  after { subject.stop_server }
 
   context "Turned on" do
     it "exposes metrics" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,14 @@
-require "bundler/setup"
 
 if ENV['CI']
   require 'simplecov'
   SimpleCov.start
 end
 
+require "bundler/setup"
 require "topological_inventory/azure/collectors_pool"
+
+require "rspec"
+require "webmock/rspec"
 
 RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`

--- a/spec/topological_inventory/azure/operations/source_spec.rb
+++ b/spec/topological_inventory/azure/operations/source_spec.rb
@@ -1,0 +1,6 @@
+require "topological_inventory/azure/operations/source"
+require File.join(Gem::Specification.find_by_name("topological_inventory-providers-common").gem_dir, "spec/support/shared/availability_check.rb")
+
+RSpec.describe(TopologicalInventory::Azure::Operations::Source) do
+  it_behaves_like "availability_check" # in providers-common
+end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/206

This PR moves Source#availability_check from AnsibleTower to providers-common. 

---

**Depends on**:

* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/25
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/28
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/33
* [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/34
---

[TPINVTRY-944](https://projects.engineering.redhat.com/browse/TPINVTRY-944)