### PR TITLE
Remove Argument from connection_check to fix ArgumentError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "activesupport", '~> 5.2.4.3'
 gem "cloudwatchlogger", "~> 0.2"
 gem "concurrent-ruby"
 gem "manageiq-loggers", "~> 0.5.0"
-gem 'manageiq-messaging', '~> 0.1.2'
+gem 'manageiq-messaging', '~> 0.1.5'
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"

--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
 
         private
 
-        def connection_check(source_id)
+        def connection_check
           TopologicalInventory::Azure::Connection.all_subscriptions(
             :client_id     => authentication.username,
             :client_secret => authentication.password,


### PR DESCRIPTION
Turns out the miq-messaging gem wasn't the culprit, it was the recent availability_check refactor that changed the method signature of the `operations/source#connection_check` which changed it from an argument to an attr_accessor method, seen here: 
https://github.com/RedHatInsights/topological_inventory-providers-common/blob/5c04f92462815485bffcb4f798bb82a490e28a82/lib/topological_inventory/providers/common/operations/source.rb#L21-L27 

cc @syncour