### PR TITLE
Bump common gem to 1.0.6 to get error handling in availability_check code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 1.0.5"
+gem "topological_inventory-providers-common", "~> 1.0.6"
 
 group :test, :development do
   gem "rspec"


### PR DESCRIPTION
*Depends on:*
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/38
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/39
