### PR TITLE
Fixed tenant_id in availability_check

### DIFF
--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -14,7 +14,7 @@ module TopologicalInventory
           TopologicalInventory::Azure::Connection.all_subscriptions(
             :client_id     => authentication.username,
             :client_secret => authentication.password,
-            :tenant_id     => authentication.extra&.dig("azure", "tenant_id")
+            :tenant_id     => authentication.extra&.azure&.tenant_id
           )
 
           [STATUS_AVAILABLE, nil]


### PR DESCRIPTION
Availability check is returning error `undefined method 'dig' for #<SourcesApiClient::AuthenticationExtra:0x00007f4a345342d0>`

The openapi changed definition of the "extra" column as a set of new classes (Authentication -> AuthenticationExtra -> AuthenticationExtraAzure)

---

[TPINVTRY-1064](https://projects.engineering.redhat.com/browse/TPINVTRY-1064)