### PR TITLE
Operations refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 1.0.10"
+gem "topological_inventory-providers-common", "~> 2.0.0"
 
 group :test, :development do
   gem "rspec"

--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -24,7 +24,7 @@ module TopologicalInventory
         end
 
         def authentication
-          @authentication ||= api_client.fetch_authentication(source_id, endpoint, 'tenant_id_client_id_client_secret')
+          @authentication ||= sources_api.fetch_authentication(source_id, endpoint, 'tenant_id_client_id_client_secret')
         end
       end
     end


### PR DESCRIPTION
Unifying names changed `api_client` to `sources_api`

---

**Depends on**:

- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/52
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/53

---

[RHCLOUD-9343](https://issues.redhat.com/browse/RHCLOUD-9343) 