### PR TITLE
Custom metrics for operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 2.0.0"
+gem "topological_inventory-providers-common", "~> 2.1.0"
 
 group :test, :development do
   gem "rspec"

--- a/bin/azure-operations
+++ b/bin/azure-operations
@@ -2,15 +2,48 @@
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
 require "bundler/setup"
+require "optimist"
 require "topological_inventory/azure/operations/worker"
+require "topological_inventory/azure/operations/metrics"
 
-queue_host = ENV["QUEUE_HOST"] || "localhost"
-queue_port = ENV["QUEUE_PORT"] || 9092
+def parse_args
+  Optimist.options do
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
 
-SourcesApiClient.configure do |config|
-  config.scheme = ENV["SOURCES_SCHEME"]
-  config.host   = "#{ENV["SOURCES_HOST"]}:#{ENV["SOURCES_PORT"]}"
+    opt :queue_host, "Kafka messaging: hostname or IP", :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
+    opt :queue_port, "Kafka messaging: port", :type => :integer, :default => (ENV["QUEUE_PORT"] || 9092).to_i
+
+    opt :sources_scheme, "Sources API scheme", :type => :string, :default => ENV["SOURCES_SCHEME"] || "http"
+    opt :sources_host, "Sources API host name", :type => :string, :default => ENV["SOURCES_HOST"]
+    opt :sources_port, "Sources API port", :type => :integer, :default => ENV["SOURCES_PORT"].to_i
+  end
 end
 
-operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:host => queue_host, :port => queue_port)
+def check_args(args)
+  %i[queue_host queue_port
+     sources_scheme sources_host sources_port].each do |arg|
+    Optimist.die arg, "can't be blank" if args[arg].blank?
+    Optimist.die arg, "can't be zero" if arg.to_s.index('port').present? && args[arg].zero?
+  end
+end
+
+args = parse_args
+check_args(args)
+
+SourcesApiClient.configure do |config|
+  config.scheme = args[:sources_scheme] || "http"
+  config.host   = "#{args[:sources_host]}:#{args[:sources_port]}"
+end
+
+metrics = TopologicalInventory::Azure::Operations::Metrics.new(args[:metrics_port])
+
+Signal.trap("TERM") do
+  metrics.stop_server
+  exit
+end
+
+operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:host    => args[:queue_host],
+                                                                        :metrics => metrics,
+                                                                        :port    => args[:queue_port])
 operations_worker.run

--- a/lib/topological_inventory/azure/operations/metrics.rb
+++ b/lib/topological_inventory/azure/operations/metrics.rb
@@ -1,0 +1,17 @@
+require 'topological_inventory/providers/common/metrics'
+
+module TopologicalInventory
+  module Azure
+    module Operations
+      class Metrics < TopologicalInventory::Providers::Common::Metrics
+        def initialize(port = 9394)
+          super(port)
+        end
+
+        def default_prefix
+          "topological_inventory_azure_operations_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/azure/operations/processor.rb
+++ b/lib/topological_inventory/azure/operations/processor.rb
@@ -1,43 +1,14 @@
 require "topological_inventory/azure/logging"
+require "topological_inventory/providers/common/operations/processor"
 
 module TopologicalInventory
   module Azure
     module Operations
-      class Processor
+      class Processor < TopologicalInventory::Providers::Common::Operations::Processor
         include Logging
 
-        def self.process!(message)
-          new(message).process
-        end
-
-        def initialize(message)
-          self.message = message
-          self.model, self.method = message.message.split(".")
-
-          self.params   = message.payload["params"]
-          self.identity = message.payload["request_context"]
-        end
-
-        def process
-          logger.info(status_log_msg)
-
-          impl = Operations.const_get(model).new(params, identity) if Operations.const_defined?(model)
-          if impl&.respond_to?(method)
-            result = impl.send(method)
-
-            logger.info(status_log_msg("Complete"))
-            result
-          else
-            logger.warn(status_log_msg("Not Implemented!"))
-          end
-        end
-
-        private
-
-        attr_accessor :message, :identity, :model, :method, :params
-
-        def status_log_msg(status = nil)
-          "Processing #{model}##{method} [#{params}]...#{status}"
+        def operation_class
+          "#{Operations}::#{model}".safe_constantize
         end
       end
     end

--- a/lib/topological_inventory/azure/operations/source.rb
+++ b/lib/topological_inventory/azure/operations/source.rb
@@ -23,8 +23,13 @@ module TopologicalInventory
           [STATUS_UNAVAILABLE, e.message]
         end
 
+        # called only for endpoint_connection_check()
         def authentication
           @authentication ||= sources_api.fetch_authentication(source_id, endpoint, 'tenant_id_client_id_client_secret')
+        rescue => e
+          metrics&.record_error(:sources_api)
+          logger.error_ext(operation, "Failed to fetch Authentication for Source #{source_id}: #{e.message}")
+          nil
         end
       end
     end

--- a/spec/topological_inventory/azure/operations/processor_spec.rb
+++ b/spec/topological_inventory/azure/operations/processor_spec.rb
@@ -1,0 +1,26 @@
+require "topological_inventory/azure/operations/processor"
+
+RSpec.describe TopologicalInventory::Azure::Operations::Processor do
+  let(:message) { double("ManageIQ::Messaging::ReceivedMessage", :message => operation_name, :payload => payload) }
+  let(:operation_name) { 'Testing.operation' }
+  let(:params) { {'source_id' => 1, 'external_tenant' => '12345'} }
+  let(:payload) { {"params" => params, "request_context" => double('request_context')} }
+
+  subject { described_class.new(message, nil) }
+
+  describe "#process" do
+    context "Source.availability_check task" do
+      let(:source_class) { TopologicalInventory::Azure::Operations::Source }
+      let(:operation_name) { 'Source.availability_check' }
+
+      it "runs availability check" do
+        source = source_class.new(params)
+        allow(source_class).to receive(:new).and_return(source)
+
+        expect(source).to receive(:availability_check)
+
+        subject.process
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

(similar PR like https://github.com/RedHatInsights/topological_inventory-amazon/pull/77)

Metrics for Availability_check:
* topological_inventory_azure_operations:
  * _status_counter (args: operation name and result) [counter]
  * _duration_seconds [histogram]

**Important: Error metric replaces restart of pod in case of error**

---

* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/57

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)