### PR TITLE
Add messaging client for operations

### DIFF
--- a/bin/azure-operations
+++ b/bin/azure-operations
@@ -43,7 +43,15 @@ Signal.trap("TERM") do
   exit
 end
 
-operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:host    => args[:queue_host],
-                                                                        :metrics => metrics,
-                                                                        :port    => args[:queue_port])
-operations_worker.run
+TopologicalInventory::Azure::MessagingClient.configure do |config|
+  config.queue_host = args[:queue_host]
+  config.queue_port = args[:queue_port]
+end
+
+begin
+  operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:metrics => metrics)
+  operations_worker.run
+rescue => err
+  puts err
+  raise
+end

--- a/lib/topological_inventory/azure/messaging_client.rb
+++ b/lib/topological_inventory/azure/messaging_client.rb
@@ -1,0 +1,39 @@
+require "manageiq-messaging"
+require "topological_inventory/providers/common/messaging_client"
+
+module TopologicalInventory
+  module Azure
+    class MessagingClient < TopologicalInventory::Providers::Common::MessagingClient
+      OPERATIONS_QUEUE_NAME = "platform.topological-inventory.operations-azure".freeze
+
+      # Instance of messaging client for Worker
+      def worker_listener
+        @worker_listener ||= ManageIQ::Messaging::Client.open(worker_listener_opts)
+      end
+
+      def worker_listener_queue_opts
+        {
+          :auto_ack    => false,
+          :max_bytes   => 50_000,
+          :service     => OPERATIONS_QUEUE_NAME,
+          :persist_ref => "topological-inventory-operations-azure"
+        }
+      end
+
+      private
+
+      def worker_listener_opts
+        {
+          :client_ref => default_client_ref,
+          :host       => @queue_host,
+          :port       => @queue_port,
+          :protocol   => :Kafka
+        }
+      end
+
+      def default_client_ref
+        ENV['HOSTNAME'].presence || SecureRandom.hex(4)
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/azure/operations/worker.rb
+++ b/lib/topological_inventory/azure/operations/worker.rb
@@ -1,4 +1,5 @@
 require "topological_inventory/azure/logging"
+require "topological_inventory/azure/messaging_client"
 require "topological_inventory/azure/operations/processor"
 require "topological_inventory/azure/operations/source"
 require "topological_inventory/providers/common/mixins/statuses"
@@ -11,27 +12,33 @@ module TopologicalInventory
         include Logging
         include TopologicalInventory::Providers::Common::Mixins::Statuses
 
-        def initialize(host:, port:, metrics:)
-          self.messaging_client_opts = default_messaging_opts.merge(:host => host, :port => port)
-          self.metrics               = metrics
+        def initialize(metrics:)
+          self.metrics = metrics
         end
 
         def run
-          # Open a connection to the messaging service
-          require "manageiq-messaging"
-          client = ManageIQ::Messaging::Client.open(messaging_client_opts)
-
           logger.info("Topological Inventory Azure Operations worker started...")
+
           client.subscribe_topic(queue_opts) do |message|
             process_message(message)
           end
+        rescue => err
+          logger.error("#{err.cause}\n#{err.backtrace.join("\n")}")
         ensure
           client&.close
         end
 
         private
 
-        attr_accessor :messaging_client_opts, :metrics
+        attr_accessor :metrics
+
+        def client
+          @client ||= TopologicalInventory::Azure::MessagingClient.default.worker_listener
+        end
+
+        def queue_opts
+          TopologicalInventory::Azure::MessagingClient.default.worker_listener_queue_opts
+        end
 
         def process_message(message)
           result = Processor.process!(message, metrics)
@@ -42,27 +49,6 @@ module TopologicalInventory
         ensure
           message.ack
           TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
-        end
-
-        def queue_name
-          "platform.topological-inventory.operations-azure"
-        end
-
-        def queue_opts
-          {
-            :auto_ack    => false,
-            :max_bytes   => 50_000,
-            :service     => queue_name,
-            :persist_ref => "topological-inventory-operations-azure"
-          }
-        end
-
-        def default_messaging_opts
-          {
-            :protocol   => :Kafka,
-            :client_ref => "topological-inventory-operations-azure",
-            :group_ref  => "topological-inventory-operations-azure"
-          }
         end
       end
     end

--- a/spec/topological_inventory/azure/operations/worker_spec.rb
+++ b/spec/topological_inventory/azure/operations/worker_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe TopologicalInventory::Azure::Operations::Worker do
     let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
     let(:metrics) { double("Metrics", :record_operation => nil) }
     let(:operation) { 'Test.operation' }
-    let(:subject) { described_class.new(:host => 'localhost', :port => 9092, :metrics => metrics) }
+    let(:subject) { described_class.new(:metrics => metrics) }
 
     before do
-      require "manageiq-messaging"
-      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      TopologicalInventory::Azure::MessagingClient.class_variable_set(:@@default, nil)
+      allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
       allow(TopologicalInventory::Providers::Common::Operations::HealthCheck).to receive(:touch_file)
       allow(message).to receive_messages(:ack => nil, :message => operation)


### PR DESCRIPTION
Adding a new messaging client similiar to the ansible-tower repo to be more consitent.

This PR is based on the https://issues.redhat.com/browse/RHCLOUD-9328