### PR TITLE
Operations Worker cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 2.1.0"
+gem "topological_inventory-providers-common", "~> 2.1.1"
 
 group :test, :development do
   gem "rspec"

--- a/bin/azure-operations
+++ b/bin/azure-operations
@@ -43,7 +43,15 @@ Signal.trap("TERM") do
   exit
 end
 
-operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:host    => args[:queue_host],
-                                                                        :metrics => metrics,
-                                                                        :port    => args[:queue_port])
-operations_worker.run
+TopologicalInventory::Azure::MessagingClient.configure do |config|
+  config.queue_host = args[:queue_host]
+  config.queue_port = args[:queue_port]
+end
+
+begin
+  operations_worker = TopologicalInventory::Azure::Operations::Worker.new(metrics)
+  operations_worker.run
+rescue => err
+  puts err
+  raise
+end

--- a/lib/topological_inventory/azure/messaging_client.rb
+++ b/lib/topological_inventory/azure/messaging_client.rb
@@ -1,0 +1,39 @@
+require "manageiq-messaging"
+require "topological_inventory/providers/common/messaging_client"
+
+module TopologicalInventory
+  module Azure
+    class MessagingClient < TopologicalInventory::Providers::Common::MessagingClient
+      OPERATIONS_QUEUE_NAME = "platform.topological-inventory.operations-azure".freeze
+
+      # Instance of messaging client for Worker
+      def worker_listener
+        @worker_listener ||= ManageIQ::Messaging::Client.open(worker_listener_opts)
+      end
+
+      def worker_listener_queue_opts
+        {
+          :auto_ack    => false,
+          :max_bytes   => 50_000,
+          :service     => OPERATIONS_QUEUE_NAME,
+          :persist_ref => "topological-inventory-operations-azure"
+        }
+      end
+
+      private
+
+      def worker_listener_opts
+        {
+          :client_ref => default_client_ref,
+          :host       => @queue_host,
+          :port       => @queue_port,
+          :protocol   => :Kafka
+        }
+      end
+
+      def default_client_ref
+        ENV['HOSTNAME'].presence || SecureRandom.hex(4)
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/azure/operations/worker_spec.rb
+++ b/spec/topological_inventory/azure/operations/worker_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe TopologicalInventory::Azure::Operations::Worker do
     let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
     let(:metrics) { double("Metrics", :record_operation => nil) }
     let(:operation) { 'Test.operation' }
-    let(:subject) { described_class.new(:host => 'localhost', :port => 9092, :metrics => metrics) }
+    let(:subject) { described_class.new(metrics) }
 
     before do
-      require "manageiq-messaging"
-      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      TopologicalInventory::Azure::MessagingClient.class_variable_set(:@@default, nil)
+      allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
       allow(TopologicalInventory::Providers::Common::Operations::HealthCheck).to receive(:touch_file)
       allow(message).to receive_messages(:ack => nil, :message => operation)


### PR DESCRIPTION
Because number of args for worker was decreased to 1, it's not worth using hash-style args