### PR TITLE
Operations Worker cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 2.1.0"
+gem "topological_inventory-providers-common", "~> 2.1.1"
 
 group :test, :development do
   gem "rspec"

--- a/bin/azure-operations
+++ b/bin/azure-operations
@@ -49,7 +49,7 @@ TopologicalInventory::Azure::MessagingClient.configure do |config|
 end
 
 begin
-  operations_worker = TopologicalInventory::Azure::Operations::Worker.new(:metrics => metrics)
+  operations_worker = TopologicalInventory::Azure::Operations::Worker.new(metrics)
   operations_worker.run
 rescue => err
   puts err

--- a/lib/topological_inventory/azure/operations/worker.rb
+++ b/lib/topological_inventory/azure/operations/worker.rb
@@ -12,7 +12,7 @@ module TopologicalInventory
         include Logging
         include TopologicalInventory::Providers::Common::Mixins::Statuses
 
-        def initialize(metrics:)
+        def initialize(metrics)
           self.metrics = metrics
         end
 

--- a/spec/topological_inventory/azure/operations/worker_spec.rb
+++ b/spec/topological_inventory/azure/operations/worker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TopologicalInventory::Azure::Operations::Worker do
     let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
     let(:metrics) { double("Metrics", :record_operation => nil) }
     let(:operation) { 'Test.operation' }
-    let(:subject) { described_class.new(:metrics => metrics) }
+    let(:subject) { described_class.new(metrics) }
 
     before do
       TopologicalInventory::Azure::MessagingClient.class_variable_set(:@@default, nil)


### PR DESCRIPTION
Because number of args for worker was decreased to 1, it's not worth using hash-style args