### PR TITLE
Bump providers-common to 2.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 2.1.1"
+gem "topological_inventory-providers-common", "~> 2.1.2"
 
 group :test, :development do
   gem "rspec"

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TopologicalInventory::Azure::Collector::Metrics do
       subject.record_error(err_type)
 
       metrics = get_metrics
-      expect(metrics["topological_inventory_azure_collector_error{type=\"#{err_type}\"}"]).to eq("2")
+      expect(metrics["topological_inventory_azure_collector_errors_total{type=\"#{err_type}\"}"]).to eq("2")
     end
 
     def get_metrics


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-providers-common/issues/66

---

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)