### PR TITLE
Update travis URL in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # topological_inventory-azure
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-azure.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-azure)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-azure.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-azure)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f02d931e79344fc2481b/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-azure/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/f02d931e79344fc2481b/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-azure/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-azure/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-azure/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.