### PR TITLE
Bump Providers-Common to 2.1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.2"
-gem "topological_inventory-providers-common", "~> 2.1.2"
+gem "topological_inventory-providers-common", "~> 2.1.3"
 
 group :test, :development do
   gem "rspec"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/sources-api/issues/286

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/70

---

[RHCLOUD-10879](https://issues.redhat.com/browse/RHCLOUD-10879)